### PR TITLE
Crud categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "lint": "./node_modules/.bin/standard",
     "lint-fix": "./node_modules/.bin/standard --fix",
-    "start": "react-scripts --openssl-legacy-provider start",
-    "start-linux": "react-scripts start",
+    "start-legacy": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/components/BackOffice/Categories/CategoriesList/index.js
+++ b/src/components/BackOffice/Categories/CategoriesList/index.js
@@ -1,11 +1,16 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import CategoryCard from '../CategoryCard'
 import { Container, Head } from './styles'
+import { FaPlus } from "react-icons/fa"
+
 
 export default function CategoriesList({ categories }) {
   return (
     <Container>
       <h1>Categorias ( {categories.length} )</h1>
+      <Link to={`new`}><FaPlus /> Agregar Nueva</Link>
+
       <Head>
         <div className='name' >Nombre</div>
         {/* <div className='description'>Descripcion</div> */}

--- a/src/components/BackOffice/Categories/CategoriesList/styles.js
+++ b/src/components/BackOffice/Categories/CategoriesList/styles.js
@@ -8,6 +8,17 @@ export const Container = styled.section`
   &>h1 {
     text-align: center ;
   }
+  a {
+    text-align: center ;
+    font-size: 1rem;
+    text-decoration: none;
+    &:hover {
+      color: #0000FF
+    }
+    svg {
+      padding-left: 2rem ;
+    }
+  }
 
   ${screenLittle} {
     width: 500px ;

--- a/src/components/BackOffice/Categories/CategoryCard/index.js
+++ b/src/components/BackOffice/Categories/CategoryCard/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { FaTrash, FaEdit } from 'react-icons/fa'
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import { alertToast, confirm } from 'services/alerts';
 import { deleteCategories } from 'store/slices/categories';
 import { Card, Row } from './styles'
@@ -13,9 +14,11 @@ export default function CategoryCard({ category }) {
   const [deleteCategory, setDeleteCategory] = useState(false)
   const dispatch = useDispatch()
 
+const navigate = useNavigate()
+
   const handleEdit = (id) => {
     console.log(`el category id es: ${id}`);
-    console.log({category});
+    navigate(`${id}`)
   }
 
   const handleDelete = () => {

--- a/src/components/BackOffice/Categories/CategoryCard/index.js
+++ b/src/components/BackOffice/Categories/CategoryCard/index.js
@@ -17,7 +17,6 @@ export default function CategoryCard({ category }) {
 const navigate = useNavigate()
 
   const handleEdit = (id) => {
-    console.log(`el category id es: ${id}`);
     navigate(`${id}`)
   }
 

--- a/src/components/Forms/index.js
+++ b/src/components/Forms/index.js
@@ -18,6 +18,7 @@ export const FormikForm = ({
       <OperationName>{operationName}</OperationName>
       <Formik
         initialValues={values}
+        enableReinitialize
         validationSchema={schema}
         onSubmit={onSubmit}
       >

--- a/src/components/Forms/schemas.js
+++ b/src/components/Forms/schemas.js
@@ -61,3 +61,14 @@ export const contactSchema= Yup.object().shape({
     .required('El mensaje es requerido')
 })
 
+export const categorySchema= Yup.object().shape({
+  name: Yup.string()
+    .matches(/^[aA-zZ\s]+$/, 'Solo se admiten letras')
+    .min(3, 'El mínimo de caracteres es 3')
+    .max(30, 'El máximo de caracteres es 30')
+    .required('El nombre es requerido'),
+  description: Yup.string()
+    .matches(/^[aA-zZ\s]+$/, 'Solo se admiten letras')
+    .max(250, 'El máximo de caracteres es 250'),
+    // .required('El apellido es requerido'),
+})

--- a/src/components/Slider/index.js
+++ b/src/components/Slider/index.js
@@ -8,7 +8,7 @@ const Slider = ({title=''}) => {
 		<Container>
 			<Titulo>{title}</Titulo>
 			<Slideshow controles={true} autoplay={true} velocidad="1000" intervalo="2000">
-				{images.map(img => <Slide>
+				{images.map((img, index) => <Slide key={index}>
           <a href={img.link}>
 						<img src={img.img} alt=""/>
 					</a>

--- a/src/pages/BackOffice/Categories/CategoryForm/index.js
+++ b/src/pages/BackOffice/Categories/CategoryForm/index.js
@@ -2,17 +2,20 @@ import React, { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { Container, FormContainer } from "./styles";
+import { Button, Container, FormContainer } from "./styles";
 import { categorySchema } from "components/Forms/schemas";
 import { FormikForm } from "components/Forms";
 import { FormField } from "components/Forms/formField";
 import { getService } from "services/apiService";
 import { ENDPOINT_CATEGORIES } from "services/settings";
 import { TiArrowBack } from "react-icons/ti";
-import { createCategories } from "store/slices/categories";
+import { createCategories, updateCategories } from "store/slices/categories";
+import { useSelector } from "react-redux";
+import { alertToast } from "services/alerts";
+import Loader from "components/utils/Loader";
 
 
-const FormFields = () => {
+const FormFields = (editar=false) => {
   return (
     <>
       <FormField
@@ -27,12 +30,13 @@ const FormFields = () => {
         placeholder="Descripcion"
         FormContainer={FormContainer}
       />
-      <button type="submit">Aceptar</button>
+      <Button type="submit">{editar ? 'Editar' : 'Agregar'}</Button>
     </>
   )
 }
 
 export const CategoryForm = () => {
+  const {isError, isSuccess, isLoading, message } = useSelector(state => state.categories)
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
@@ -56,38 +60,25 @@ export const CategoryForm = () => {
           description,
         });
       }
-    })();
+    })()
   }, [params.id, getService]);
 
-  // //Login req
   const handleSubmit = (values,actions) => {
-    console.log('···submiting',  category);
     if (params.id) {
-      console.log('updatePost', values)
-
+      dispatch(updateCategories({...values, id:params.id}))
     } else {
       dispatch(createCategories(values))
     }
-    actions.resetForm();
+    if (isSuccess) alertToast('success',params.id ?'Categoria editada correctamente!':'Categoria agregada correctamente!')
+    if (isError) alertToast('error',message)
+
     actions.setSubmitting(false);
-    navigate("/backoffice/categories");
+    actions.resetForm();
+    navigate("/backoffice/categories")
   }
 
-  // //Effects/notifications 
-  // useEffect(() => {
-  //     if(isError){
-  //         alertToast('error',message)
-  //     }
-  //     if(isSuccess || user){
-  //         alertToast('success','Inicio de sesión exitoso!')
-  //         navigate('/home')
-  //     }
-  //     dispatch(reset())
-  // }, [user, isError, isSuccess, message, navigate, dispatch])
-
-  /*if(isLoading) {
-    //Loading screen, check preserve the state of the fields for not write all again after re-render
-  }*/
+  
+  if(isLoading) return <Loader />
 
   return (
     <Container>
@@ -95,11 +86,11 @@ export const CategoryForm = () => {
       <FormikForm
         title="Back Office"
         subtitle="Administracion de categorias"
-        operationName="Agregar/Editar" /*Delete for delete Iniciar sesion text*/
+        operationName= {params.id ? 'Editar' : 'Agregar'}
         values={category}
         schema={categorySchema}
         onSubmit={handleSubmit}
-        FormFields={() => FormFields()}
+        FormFields={() => FormFields(params.id ? true : false)}
       />
     </Container>
   )

--- a/src/pages/BackOffice/Categories/CategoryForm/index.js
+++ b/src/pages/BackOffice/Categories/CategoryForm/index.js
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { Container, FormContainer } from "./styles";
+import { categorySchema } from "components/Forms/schemas";
+import { FormikForm } from "components/Forms";
+import { FormField } from "components/Forms/formField";
+import { getService } from "services/apiService";
+import { ENDPOINT_CATEGORIES } from "services/settings";
+import { TiArrowBack } from "react-icons/ti";
+import { createCategories } from "store/slices/categories";
+
+
+const FormFields = () => {
+  return (
+    <>
+      <FormField
+        name="name"
+        type="text"
+        placeholder="Nombre"
+        FormContainer={FormContainer}
+      />
+      <FormField
+        name="description"
+        type="text"
+        placeholder="Descripcion"
+        FormContainer={FormContainer}
+      />
+      <button type="submit">Aceptar</button>
+    </>
+  )
+}
+
+export const CategoryForm = () => {
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
+
+  const params = useParams()
+
+  const values = {
+    name: '',
+    description: ''
+  }
+
+  const [category, setCategory] = useState(values);
+
+  useEffect(() => {
+    (async () => {
+      if (params.id) {
+        const response = await getService(ENDPOINT_CATEGORIES, params.id);
+        const { name, description } = response.data
+
+        setCategory({
+          name,
+          description,
+        });
+      }
+    })();
+  }, [params.id, getService]);
+
+  // //Login req
+  const handleSubmit = (values,actions) => {
+    console.log('···submiting',  category);
+    if (params.id) {
+      console.log('updatePost', values)
+
+    } else {
+      dispatch(createCategories(values))
+    }
+    actions.resetForm();
+    actions.setSubmitting(false);
+    navigate("/backoffice/categories");
+  }
+
+  // //Effects/notifications 
+  // useEffect(() => {
+  //     if(isError){
+  //         alertToast('error',message)
+  //     }
+  //     if(isSuccess || user){
+  //         alertToast('success','Inicio de sesión exitoso!')
+  //         navigate('/home')
+  //     }
+  //     dispatch(reset())
+  // }, [user, isError, isSuccess, message, navigate, dispatch])
+
+  /*if(isLoading) {
+    //Loading screen, check preserve the state of the fields for not write all again after re-render
+  }*/
+
+  return (
+    <Container>
+      <Link to={`/backoffice/categories`}><TiArrowBack /> Volver a Categorias</Link>
+      <FormikForm
+        title="Back Office"
+        subtitle="Administracion de categorias"
+        operationName="Agregar/Editar" /*Delete for delete Iniciar sesion text*/
+        values={category}
+        schema={categorySchema}
+        onSubmit={handleSubmit}
+        FormFields={() => FormFields()}
+      />
+    </Container>
+  )
+}
+
+

--- a/src/pages/BackOffice/Categories/CategoryForm/styles.js
+++ b/src/pages/BackOffice/Categories/CategoryForm/styles.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components'
+
+export const FormContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  width: 30%;
+`
+
+export const Container = styled.div`
+  border: 1px solid red;
+  width: 400px;
+  margin: auto ;
+  color: black;
+  padding: 1rem;
+
+  a {
+    text-align: center ;
+    font-size: 1rem;
+    text-decoration: none;
+    &:hover {
+      color: #0000FF
+    }
+    svg {
+      padding-left: 2rem ;
+    }
+  }
+  
+`

--- a/src/pages/BackOffice/Categories/CategoryForm/styles.js
+++ b/src/pages/BackOffice/Categories/CategoryForm/styles.js
@@ -4,11 +4,26 @@ export const FormContainer = styled.div`
   display: flex;
   justify-content: center;
   flex-direction: column;
-  width: 30%;
+  margin-bottom: .5rem;
+  width: 70%;
+  height: 2rem;
+  input {
+    border: 1px solid #dadde1;
+    height: 100% ;
+  }
+  input:hover {
+    border-color: #764abc ;
+  }
 `
-
+export const Button = styled.button`
+    background-color: #eae7fe;
+    border-color: transparent ;
+    border-radius: 5rem ;
+    cursor: pointer;
+    display: block ;
+    width: 70%;
+`
 export const Container = styled.div`
-  border: 1px solid red;
   width: 400px;
   margin: auto ;
   color: black;

--- a/src/pages/BackOffice/Categories/index.js
+++ b/src/pages/BackOffice/Categories/index.js
@@ -8,7 +8,6 @@ function Categories () {
   const { categories } = useSelector(state => state.categories)
   const dispatch = useDispatch()
   useEffect(() => {
-
     dispatch(fetchAllCategories())
   }, [dispatch])
 

--- a/src/routesWeb.js
+++ b/src/routesWeb.js
@@ -11,6 +11,7 @@ import Categories from 'pages/BackOffice/Categories'
 import {  useSelector } from 'react-redux'
 import Users from 'pages/BackOffice/Users'
 import New from 'pages/New'
+import { CategoryForm } from 'pages/BackOffice/Categories/CategoryForm'
 
 export default function RoutesWeb () {
   
@@ -33,6 +34,8 @@ export default function RoutesWeb () {
         <>
           <Route path='/backoffice/users' element={<Users />} />
           <Route path='/backoffice/categories' element={<Categories />} />
+          <Route path='/backoffice/categories/new' element={<CategoryForm />} />
+          <Route path='/backoffice/categories/:id' element={<CategoryForm />} />
         </>
       }
     </Routes>

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -24,21 +24,12 @@ export const deleteService = (apiEndpoint, id) => {
   return fetcher('delete', apiServiceUrl)
 }
 
+export const updateService = (apiEndpoint, id, data) => {
+  const apiServiceUrl = `${apiEndpoint}/${id}`
+  return fetcher('patch', apiServiceUrl, data)
+}
+
 export const postService = (apiEndpoint, data) => {
   const apiServiceUrl = `${apiEndpoint}`
   return fetcher('post', apiServiceUrl, data)
 }
-
-// TODO con fetcher
-// export const deleteService = (apiEndpoint, id) => {
-//   if (!id) return 'error'
-//   const apiServiceUrl = `${apiEndpoint}/${id}`
-//   return apiService.delete(apiServiceUrl).catch((err) => {
-//     console.log(err)
-//     const error = {
-//       error: true,
-//       message: err.message
-//     }
-//     return error
-//   })
-// }

--- a/src/store/slices/categories/index.js
+++ b/src/store/slices/categories/index.js
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { deleteService, getService, postService } from 'services/apiService'
+import { deleteService, getService, postService, updateService } from 'services/apiService'
 import { ENDPOINT_CATEGORIES } from "services/settings"
 
 const initialState = {
@@ -47,6 +47,7 @@ export const categorySlice = createSlice({
                 state.categories = [...state.categories, action.payload] 
             })
             .addCase(createCategories.rejected, (state, action) => {
+                console.log('puto',action.payload);
                 state.isLoading = false
                 state.isError = true
                 state.message = action.payload
@@ -57,7 +58,6 @@ export const categorySlice = createSlice({
                 state.isError = false
             })
             .addCase(deleteCategories.fulfilled, (state, action) => {
-                console.log('id: ', action.payload);
                 const filteredCategories = state.categories.filter(e => e.id !== action.payload)
                 state.isLoading = false
                 state.isSuccess = true
@@ -65,6 +65,24 @@ export const categorySlice = createSlice({
                 state.categories = filteredCategories
             })
             .addCase(deleteCategories.rejected, (state, action) => {
+                state.isLoading = false
+                state.isSuccess = false
+                state.isError = true
+                state.message = action.payload
+            })
+            .addCase(updateCategories.pending, (state) => {
+                state.isLoading = true
+                state.isSuccess = false
+                state.isError = false
+            })
+            .addCase(updateCategories.fulfilled, (state, action) => {
+                const updatedCategories = state.categories.map(e => e.id === action.payload.id ? action.payload.data : e )
+                state.isLoading = false
+                state.isSuccess = true
+                state.isError = false
+                state.categories = updatedCategories
+            })
+            .addCase(updateCategories.rejected, (state, action) => {
                 state.isLoading = false
                 state.isSuccess = false
                 state.isError = true
@@ -82,7 +100,7 @@ export const createCategories = createAsyncThunk('create/categories', async (dat
          const response = await postService(ENDPOINT_CATEGORIES, data)
         return data
     } catch (error) {
-        const message = (error.response && error.response.data && error.response.data.message) || error.message || error.toString()
+        const message = (error.response.data?.msg || error.response.data) || (error.response && error.response.data && error.response.data.message) || error.message || error.toString()
         return thunkAPI.rejectWithValue(message)
     }
 })
@@ -103,6 +121,17 @@ export const deleteCategories = createAsyncThunk('delete/categories', async (id,
         return id
     } catch (error) {
         const message = (error.response && error.response.data && error.response.data.message) || error.message || error.toString()
+        return thunkAPI.rejectWithValue(message)
+    }
+})
+
+export const updateCategories = createAsyncThunk('update/categories', async (data, thunkAPI) => {
+    try {
+        const {id, ...category} = data
+         const response = await updateService(ENDPOINT_CATEGORIES, id, category)
+        return {data}
+    } catch (error) {
+        const message = (error.response.data?.msg || error.response.data) || (error.response && error.response.data && error.response.data.message) || error.message || error.toString()
         return thunkAPI.rejectWithValue(message)
     }
 })

--- a/src/store/slices/categories/index.js
+++ b/src/store/slices/categories/index.js
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { deleteService, getService } from 'services/apiService'
+import { deleteService, getService, postService } from 'services/apiService'
 import { ENDPOINT_CATEGORIES } from "services/settings"
 
 const initialState = {
@@ -38,6 +38,19 @@ export const categorySlice = createSlice({
                 state.message = action.payload
                 state.categories = []
             })
+            .addCase(createCategories.pending, (state) => {
+                state.isLoading = true
+            })
+            .addCase(createCategories.fulfilled, (state, action) => {
+                state.isLoading = false
+                state.isSuccess = true
+                state.categories = [...state.categories, action.payload] 
+            })
+            .addCase(createCategories.rejected, (state, action) => {
+                state.isLoading = false
+                state.isError = true
+                state.message = action.payload
+            })
             .addCase(deleteCategories.pending, (state) => {
                 state.isLoading = true
                 state.isSuccess = false
@@ -56,7 +69,6 @@ export const categorySlice = createSlice({
                 state.isSuccess = false
                 state.isError = true
                 state.message = action.payload
-                // state.categories = []
             })
     },
 })
@@ -64,6 +76,16 @@ export const categorySlice = createSlice({
 export const { reset } = categorySlice.actions
 
 export default categorySlice.reducer
+
+export const createCategories = createAsyncThunk('create/categories', async (data, thunkAPI) => {
+    try {
+         const response = await postService(ENDPOINT_CATEGORIES, data)
+        return data
+    } catch (error) {
+        const message = (error.response && error.response.data && error.response.data.message) || error.message || error.toString()
+        return thunkAPI.rejectWithValue(message)
+    }
+})
 
 export const fetchAllCategories = createAsyncThunk('categories', async (thunkAPI) => {
     try {


### PR DESCRIPTION
**categorias-100**
> COMO: Usuario administrador
> QUIERO: Crear o editar una categoría existente
> PARA: Mantener el contenido actualizado
> 
> Criterios de aceptación: El mismo contendrá los campos Nombre (en la base de datos es name) y Descripción (en la base de datos es description). El objetivo es crear un formulario reutilizable para las acciones de edición como de creación. Para esto, deberá poder comportarse de forma diferente según recibe un objeto o no.  En el caso de no recibir un objeto, significa que está realizando una acción de creación, por lo que deberá mostrar los campos vacíos y realizar una petición POST al endpoint de creación  (/categories). En el caso de recibir un objeto, completar el formulario con los campos del mismo y realizar una petición PATCH al endpoint de actualización (/categories/:id). Este formulario se mostrará en el backoffice tanto para la creación como edición

- Add new category from categories/new
- Edit a category from categories/id
- Delete some category if it not in use, from categories/